### PR TITLE
expose actual errors rather than silently swallowing them when loading zkCoordinator config file

### DIFF
--- a/consumer_config.go
+++ b/consumer_config.go
@@ -241,7 +241,7 @@ FetchBatchTimeout %v
 		c.Strategy, c.FetchBatchSize, c.FetchBatchTimeout)
 }
 
-//Validates this ConsumerConfig. Returns a corresponding error if the ConsumerConfig is invalid and nil otherwise.
+// Validate this ConsumerConfig. Returns a corresponding error if the ConsumerConfig is invalid and nil otherwise.
 func (c *ConsumerConfig) Validate() error {
 	if c.Groupid == "" {
 		return errors.New("Groupid cannot be empty")
@@ -268,11 +268,11 @@ func (c *ConsumerConfig) Validate() error {
 	}
 
 	if c.OffsetsStorage != ZookeeperOffsetStorage && c.OffsetsStorage != KafkaOffsetStorage {
-		return errors.New(fmt.Sprintf("OffsetsStorage must be either \"%s\" or \"%s\"", ZookeeperOffsetStorage, KafkaOffsetStorage))
+		return fmt.Errorf("OffsetsStorage must be either \"%s\" or \"%s\"", ZookeeperOffsetStorage, KafkaOffsetStorage)
 	}
 
 	if c.AutoOffsetReset != SmallestOffset && c.AutoOffsetReset != LargestOffset {
-		return errors.New(fmt.Sprintf("AutoOffsetReset must be either \"%s\" or \"%s\"", SmallestOffset, LargestOffset))
+		return fmt.Errorf("AutoOffsetReset must be either \"%s\" or \"%s\"", SmallestOffset, LargestOffset)
 	}
 
 	if c.Clientid == "" {
@@ -280,7 +280,7 @@ func (c *ConsumerConfig) Validate() error {
 	}
 
 	if c.PartitionAssignmentStrategy != RangeStrategy && c.PartitionAssignmentStrategy != RoundRobinStrategy {
-		return errors.New(fmt.Sprintf("PartitionAssignmentStrategy must be either \"%s\" or \"%s\"", RangeStrategy, RoundRobinStrategy))
+		return fmt.Errorf("PartitionAssignmentStrategy must be either \"%s\" or \"%s\"", RangeStrategy, RoundRobinStrategy)
 	}
 
 	if c.NumWorkers <= 0 {
@@ -330,6 +330,41 @@ func (c *ConsumerConfig) Validate() error {
 	return nil
 }
 
+// ConsumerConfigFromFile is a helper function that loads a consumer's configuration from file.
+// The file accepts the following fields:
+//  group.id
+//  consumer.id
+//  fetch.message.max.bytes
+//  num.consumer.fetchers
+//  rebalance.max.retries
+//  queued.max.message.chunks=
+//  fetch.min.bytes
+//  fetch.wait.max.ms
+//  rebalance.backoff
+//  refresh.leader.backoff
+//  offset.commit.max.retries
+//  offset.commit.interval
+//  offsets.storage
+//  auto.offset.reset
+//  exclude.internal.topics
+//  partition.assignment.strategy
+//  num.workers
+//  max.worker.retries
+//  worker.retry.threshold
+//  worker.threshold.time.window
+//  worker.task.timeout
+//  worker.backoff
+//  worker.managers.stop.timeout
+//  fetch.batch.size
+//  fetch.batch.timeout
+//  requeue.ask.next.backoff
+//  fetch.max.retries
+//  fetch.topic.metadata.retries
+//  fetch.topic.metadata.backoff
+//  fetch.request.backoff
+//  blue.green.deployment.enabled
+// The configuration file entries should be constructed in key=value syntax. A # symbol at the beginning
+// of a line indicates a comment. Blank lines are ignored.
 func ConsumerConfigFromFile(filename string) (*ConsumerConfig, error) {
 	c, err := LoadConfiguration(filename)
 	if err != nil {
@@ -339,83 +374,83 @@ func ConsumerConfigFromFile(filename string) (*ConsumerConfig, error) {
 	config := DefaultConsumerConfig()
 	setStringConfig(&config.Groupid, c["group.id"])
 	setStringConfig(&config.Consumerid, c["consumer.id"])
-	if setDurationConfig(&config.SocketTimeout, c["socket.timeout"]) != nil {
+	if err := setDurationConfig(&config.SocketTimeout, c["socket.timeout"]); err != nil {
 		return nil, err
 	}
-	if setInt32Config(&config.FetchMessageMaxBytes, c["fetch.message.max.bytes"]) != nil {
+	if err := setInt32Config(&config.FetchMessageMaxBytes, c["fetch.message.max.bytes"]); err != nil {
 		return nil, err
 	}
-	if setIntConfig(&config.NumConsumerFetchers, c["num.consumer.fetchers"]) != nil {
+	if err := setIntConfig(&config.NumConsumerFetchers, c["num.consumer.fetchers"]); err != nil {
 		return nil, err
 	}
-	if setInt32Config(&config.QueuedMaxMessages, c["queued.max.message.chunks"]) != nil {
+	if err := setInt32Config(&config.QueuedMaxMessages, c["queued.max.message.chunks"]); err != nil {
 		return nil, err
 	}
-	if setInt32Config(&config.RebalanceMaxRetries, c["rebalance.max.retries"]) != nil {
+	if err := setInt32Config(&config.RebalanceMaxRetries, c["rebalance.max.retries"]); err != nil {
 		return nil, err
 	}
-	if setInt32Config(&config.FetchMinBytes, c["fetch.min.bytes"]) != nil {
+	if err := setInt32Config(&config.FetchMinBytes, c["fetch.min.bytes"]); err != nil {
 		return nil, err
 	}
-	if setInt32Config(&config.FetchWaitMaxMs, c["fetch.wait.max.ms"]) != nil {
+	if err := setInt32Config(&config.FetchWaitMaxMs, c["fetch.wait.max.ms"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.RebalanceBackoff, c["rebalance.backoff"]) != nil {
+	if err := setDurationConfig(&config.RebalanceBackoff, c["rebalance.backoff"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.RefreshLeaderBackoff, c["refresh.leader.backoff"]) != nil {
+	if err := setDurationConfig(&config.RefreshLeaderBackoff, c["refresh.leader.backoff"]); err != nil {
 		return nil, err
 	}
-	if setIntConfig(&config.OffsetsCommitMaxRetries, c["offset.commit.max.retries"]) != nil {
+	if err := setIntConfig(&config.OffsetsCommitMaxRetries, c["offset.commit.max.retries"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.OffsetCommitInterval, c["offset.commit.interval"]) != nil {
+	if err := setDurationConfig(&config.OffsetCommitInterval, c["offset.commit.interval"]); err != nil {
 		return nil, err
 	}
 	setStringConfig(&config.OffsetsStorage, c["offsets.storage"])
 	setStringConfig(&config.AutoOffsetReset, c["auto.offset.reset"])
 	setBoolConfig(&config.ExcludeInternalTopics, c["exclude.internal.topics"])
 	setStringConfig(&config.PartitionAssignmentStrategy, c["partition.assignment.strategy"])
-	if setIntConfig(&config.NumWorkers, c["num.workers"]) != nil {
+	if err := setIntConfig(&config.NumWorkers, c["num.workers"]); err != nil {
 		return nil, err
 	}
-	if setIntConfig(&config.MaxWorkerRetries, c["max.worker.retries"]) != nil {
+	if err := setIntConfig(&config.MaxWorkerRetries, c["max.worker.retries"]); err != nil {
 		return nil, err
 	}
-	if setInt32Config(&config.WorkerRetryThreshold, c["worker.retry.threshold"]) != nil {
+	if err := setInt32Config(&config.WorkerRetryThreshold, c["worker.retry.threshold"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.WorkerThresholdTimeWindow, c["worker.threshold.time.window"]) != nil {
+	if err := setDurationConfig(&config.WorkerThresholdTimeWindow, c["worker.threshold.time.window"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.WorkerTaskTimeout, c["worker.task.timeout"]) != nil {
+	if err := setDurationConfig(&config.WorkerTaskTimeout, c["worker.task.timeout"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.WorkerBackoff, c["worker.backoff"]) != nil {
+	if err := setDurationConfig(&config.WorkerBackoff, c["worker.backoff"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.WorkerManagersStopTimeout, c["worker.managers.stop.timeout"]) != nil {
+	if err := setDurationConfig(&config.WorkerManagersStopTimeout, c["worker.managers.stop.timeout"]); err != nil {
 		return nil, err
 	}
-	if setIntConfig(&config.FetchBatchSize, c["fetch.batch.size"]) != nil {
+	if err := setIntConfig(&config.FetchBatchSize, c["fetch.batch.size"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.FetchBatchTimeout, c["fetch.batch.timeout"]) != nil {
+	if err := setDurationConfig(&config.FetchBatchTimeout, c["fetch.batch.timeout"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.RequeueAskNextBackoff, c["requeue.ask.next.backoff"]) != nil {
+	if err := setDurationConfig(&config.RequeueAskNextBackoff, c["requeue.ask.next.backoff"]); err != nil {
 		return nil, err
 	}
-	if setIntConfig(&config.FetchMaxRetries, c["fetch.max.retries"]) != nil {
+	if err := setIntConfig(&config.FetchMaxRetries, c["fetch.max.retries"]); err != nil {
 		return nil, err
 	}
-	if setIntConfig(&config.FetchTopicMetadataRetries, c["fetch.topic.metadata.retries"]) != nil {
+	if err := setIntConfig(&config.FetchTopicMetadataRetries, c["fetch.topic.metadata.retries"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.FetchTopicMetadataBackoff, c["fetch.topic.metadata.backoff"]) != nil {
+	if err := setDurationConfig(&config.FetchTopicMetadataBackoff, c["fetch.topic.metadata.backoff"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.FetchRequestBackoff, c["fetch.request.backoff"]) != nil {
+	if err := setDurationConfig(&config.FetchRequestBackoff, c["fetch.request.backoff"]); err != nil {
 		return nil, err
 	}
 	setBoolConfig(&config.BlueGreenDeploymentEnabled, c["blue.green.deployment.enabled"])

--- a/consumer_config.go
+++ b/consumer_config.go
@@ -337,7 +337,7 @@ func (c *ConsumerConfig) Validate() error {
 //  fetch.message.max.bytes
 //  num.consumer.fetchers
 //  rebalance.max.retries
-//  queued.max.message.chunks=
+//  queued.max.message.chunks
 //  fetch.min.bytes
 //  fetch.wait.max.ms
 //  rebalance.backoff
@@ -364,7 +364,7 @@ func (c *ConsumerConfig) Validate() error {
 //  fetch.request.backoff
 //  blue.green.deployment.enabled
 // The configuration file entries should be constructed in key=value syntax. A # symbol at the beginning
-// of a line indicates a comment. Blank lines are ignored.
+// of a line indicates a comment. Blank lines are ignored. The file should end with a newline character.
 func ConsumerConfigFromFile(filename string) (*ConsumerConfig, error) {
 	c, err := LoadConfiguration(filename)
 	if err != nil {

--- a/producer_config.go
+++ b/producer_config.go
@@ -61,7 +61,7 @@ func DefaultProducerConfig() *ProducerConfig {
 //  retry.backoff
 //  timeout
 // The configuration file entries should be constructed in key=value syntax. A # symbol at the beginning
-// of a line indicates a comment. Blank lines are ignored.
+// of a line indicates a comment. Blank lines are ignored. The file should end with a newline character.
 func ProducerConfigFromFile(filename string) (*ProducerConfig, error) {
 	p, err := LoadConfiguration(filename)
 	if err != nil {

--- a/producer_config.go
+++ b/producer_config.go
@@ -46,6 +46,22 @@ func DefaultProducerConfig() *ProducerConfig {
 	}
 }
 
+// ProducerConfigFromFile is a helper function that loads a producer's configuration information from file.
+// The file accepts the following fields:
+//  client.id
+//  metadata.broker.list
+//  send.buffer.size
+//  compression.codec
+//  flush.byte.count
+//  flush.timeout
+//  batch.size
+//  max.message.bytes
+//  max.messages.per.request
+//  acks
+//  retry.backoff
+//  timeout
+// The configuration file entries should be constructed in key=value syntax. A # symbol at the beginning
+// of a line indicates a comment. Blank lines are ignored.
 func ProducerConfigFromFile(filename string) (*ProducerConfig, error) {
 	p, err := LoadConfiguration(filename)
 	if err != nil {

--- a/zk_coordinator.go
+++ b/zk_coordinator.go
@@ -976,6 +976,15 @@ func NewZookeeperConfig() *ZookeeperConfig {
 	return config
 }
 
+// ZookeeperConfigFromFile is a helper function that loads zookeeper configuration information from file.
+// The file accepts the following fields:
+//  zookeeper.connect
+//  zookeeper.kafka.Root
+//  zookeeper.connection.timeout
+//  zookeeper.max.request.retries
+//  zookeeper.request.backoff
+// The configuration file entries should be constructed in key=value syntax. A # symbol at the beginning
+// of a line indicates a comment. Blank lines are ignored.
 func ZookeeperConfigFromFile(filename string) (*ZookeeperConfig, error) {
 	z, err := LoadConfiguration(filename)
 	if err != nil {
@@ -986,13 +995,13 @@ func ZookeeperConfigFromFile(filename string) (*ZookeeperConfig, error) {
 	setStringSliceConfig(&config.ZookeeperConnect, z["zookeeper.connect"], ",")
 	setStringConfig(&config.Root, z["zookeeper.kafka.Root"])
 
-	if err = setDurationConfig(&config.ZookeeperTimeout, z["zookeeper.connection.timeout"]); err != nil {
+	if err := setDurationConfig(&config.ZookeeperTimeout, z["zookeeper.connection.timeout"]); err != nil {
 		return nil, err
 	}
-	if err = setIntConfig(&config.MaxRequestRetries, z["zookeeper.max.request.retries"]); err != nil {
+	if err := setIntConfig(&config.MaxRequestRetries, z["zookeeper.max.request.retries"]); err != nil {
 		return nil, err
 	}
-	if err = setDurationConfig(&config.RequestBackoff, z["zookeeper.request.backoff"]); err != nil {
+	if err := setDurationConfig(&config.RequestBackoff, z["zookeeper.request.backoff"]); err != nil {
 		return nil, err
 	}
 

--- a/zk_coordinator.go
+++ b/zk_coordinator.go
@@ -984,7 +984,7 @@ func NewZookeeperConfig() *ZookeeperConfig {
 //  zookeeper.max.request.retries
 //  zookeeper.request.backoff
 // The configuration file entries should be constructed in key=value syntax. A # symbol at the beginning
-// of a line indicates a comment. Blank lines are ignored.
+// of a line indicates a comment. Blank lines are ignored. The file should end with a newline character.
 func ZookeeperConfigFromFile(filename string) (*ZookeeperConfig, error) {
 	z, err := LoadConfiguration(filename)
 	if err != nil {

--- a/zk_coordinator.go
+++ b/zk_coordinator.go
@@ -986,13 +986,13 @@ func ZookeeperConfigFromFile(filename string) (*ZookeeperConfig, error) {
 	setStringSliceConfig(&config.ZookeeperConnect, z["zookeeper.connect"], ",")
 	setStringConfig(&config.Root, z["zookeeper.kafka.Root"])
 
-	if setDurationConfig(&config.ZookeeperTimeout, z["zookeeper.connection.timeout"]) != nil {
+	if err = setDurationConfig(&config.ZookeeperTimeout, z["zookeeper.connection.timeout"]); err != nil {
 		return nil, err
 	}
-	if setIntConfig(&config.MaxRequestRetries, z["zookeeper.max.request.retries"]) != nil {
+	if err = setIntConfig(&config.MaxRequestRetries, z["zookeeper.max.request.retries"]); err != nil {
 		return nil, err
 	}
-	if setDurationConfig(&config.RequestBackoff, z["zookeeper.request.backoff"]) != nil {
+	if err = setDurationConfig(&config.RequestBackoff, z["zookeeper.request.backoff"]); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This might be an issue with the other configuration load logic as well but I have not checked yet.  If you agree with what this PR is doing then I can check around and fix the others as well.