### PR TITLE
Commit first offset

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -74,6 +74,7 @@ func NewWorkerManager(id string, config *ConsumerConfig, topicPartition TopicAnd
 		batchOrder:           make([]TaskId, 0),
 		topicPartition:       topicPartition,
 		largestOffset:        InvalidOffset,
+		lastCommittedOffset:  InvalidOffset,
 		failCounter:          NewFailureCounter(config.WorkerRetryThreshold, config.WorkerThresholdTimeWindow),
 		batchProcessed:       make(chan bool),
 		managerStop:          make(chan bool),


### PR DESCRIPTION
When doing some trivial tests to understand how all this is supposed to work I ran into a problem where a consumer in a consumer group would receive the first message in a topic again after a restart, but everything would work fine if it just received two messages on the first run.

When a `WorkerManager` is created `lastCommittedOffset` is initialized to 0 which is a valid offset. Then in `commitOffset` we check `largestOffset <= wm.lastCommittedOffset` and don't commit it if they are equal, which they are.

Here's the fix and a test that fails before and succeeds after.

I might be very confused about how all this is supposed to work, but it seems to make code written with my assumptions to work.