### PR TITLE
Allow string values in Get Consumer Info

### DIFF
--- a/mirrormaker/consumer.config
+++ b/mirrormaker/consumer.config
@@ -1,1 +1,4 @@
 zookeeper.connect=source:2181
+log_level=info
+zookeeper.connection.timeout.ms=600000
+#group.id=consumer-group


### PR DESCRIPTION
We use go_kafka_client only for mirror maker feature. And find issue that the consumer info returned with strings instead of int values:

```json
{"Version": "1", "Timestamp": "12313123", "Subscription": {"test": "1"}}
```

