### PR TITLE
Fixing references for zookeeper.kafka.root - they must all be lowercase....

### DIFF
--- a/mirrormaker/consumer.config
+++ b/mirrormaker/consumer.config
@@ -1,1 +1,5 @@
 zookeeper.connect=source:2181
+#zookeeper.kafka.root=/
+#zookeeper.connection.timeout=1
+#zookeeper.max.request.retries=3
+#zookeeper.request.backoff=150000 # time in milliseconds

--- a/zk_coordinator.go
+++ b/zk_coordinator.go
@@ -1024,7 +1024,7 @@ func NewZookeeperConfig() *ZookeeperConfig {
 // ZookeeperConfigFromFile is a helper function that loads zookeeper configuration information from file.
 // The file accepts the following fields:
 //  zookeeper.connect
-//  zookeeper.kafka.Root
+//  zookeeper.kafka.root
 //  zookeeper.connection.timeout
 //  zookeeper.max.request.retries
 //  zookeeper.request.backoff
@@ -1038,7 +1038,7 @@ func ZookeeperConfigFromFile(filename string) (*ZookeeperConfig, error) {
 
 	config := NewZookeeperConfig()
 	setStringSliceConfig(&config.ZookeeperConnect, z["zookeeper.connect"], ",")
-	setStringConfig(&config.Root, z["zookeeper.kafka.Root"])
+	setStringConfig(&config.Root, z["zookeeper.kafka.root"])
 
 	if err := setDurationConfig(&config.ZookeeperTimeout, z["zookeeper.connection.timeout"]); err != nil {
 		return nil, err


### PR DESCRIPTION
When the consumer config file is read, all keys are converted to lower case. The code still looked for an uppercase "R" for consumer.kafka.Root. This has been fixed.

In addition, adding (commented out) config variables allows people to more easily find and change them for mirrormaker.