### PR TITLE
Update to use Sarma 1.4.0 tag and preserve message.Key

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,5 @@
 github.com/samuel/go-zookeeper/zk 	ad552be7b78b762b4a8040ffc5518bdaf5b7225d
-github.com/Shopify/sarama   e5e8ace555208299fd79a051b0910e56ce8d4cb9
+github.com/Shopify/sarama   4a1de384e74006b0894c911506df4b12b6b574f1
 github.com/jimlawless/cfg 4b1e3c1869d4e608fcbda6994e5f08dd9c6beaa1
 github.com/cihub/seelog 92dc4b8b540607b8187cc2f95cac200211dcd745
 github.com/rcrowley/go-metrics dee209f2455f101a5e4e593dea94872d2c62d85d

--- a/mirror_maker.go
+++ b/mirror_maker.go
@@ -269,8 +269,7 @@ func (this *MirrorMaker) produceRoutine(producer Producer, channelIndex int) {
 			}
 		}
 		if this.config.PreservePartitions {
-			sendmsg := &ProducerMessage{Topic: this.config.TopicPrefix + msg.Topic, Key: msg.Key, Value: msg.DecodedValue, Metadata: int32(msg.Partition)}
-			producer.Input() <- sendmsg
+			producer.Input() <- &ProducerMessage{Topic: this.config.TopicPrefix + msg.Topic, Key: msg.Key, Value: msg.DecodedValue, Metadata: int32(msg.Partition)}
 		} else {
 			producer.Input() <- &ProducerMessage{Topic: this.config.TopicPrefix + msg.Topic, Key: msg.Key, Value: msg.DecodedValue}
 		}

--- a/producer_sarama.go
+++ b/producer_sarama.go
@@ -157,6 +157,7 @@ func (this *SaramaProducer) initInput() {
 				Topic: message.Topic,
 				Key:   key,
 				Value: value,
+				Metadata: message.Metadata,
 			}
 			this.saramaProducer.Input() <- saramaMessage
 		}
@@ -201,13 +202,14 @@ type SaramaPartitioner struct {
 	partitioner Partitioner
 }
 
-func (this *SaramaPartitioner) Partition(key sarama.Encoder, numPartitions int32) (int32, error) {
-	keyBytes, err := key.Encode()
-	if err != nil {
-		return -1, err
+func (this *SaramaPartitioner) Partition(message *sarama.ProducerMessage, numPartitions int32) (int32, error) {
+	mmMessage := &ProducerMessage {
+		Topic: message.Topic,
+		Key:   message.Key,
+		Value: message.Value,
+		Metadata: message.Metadata,
 	}
-
-	return this.partitioner.Partition(keyBytes, numPartitions)
+	return this.partitioner.Partition(mmMessage, numPartitions)
 }
 
 func (this *SaramaPartitioner) RequiresConsistency() bool {


### PR DESCRIPTION
We like the --preserve-partition option but found that it overwrites message.Key. We use message.Key to store critical data for verification at the end of the pipeline, so I investigated a way to preserve it while still maintaining strict partition stickiness. It was convenient that the latest versions of Sarama actually support ManualPartition, but the mirror_maker.go code needed to be updated in several spots. I now have the message.Metatdata field set with partition.

This may not have enough testing (and may even break existing tests). It also has not been tested by us in other sections of code outside of mirrormaker. Despite this, we have been using the code in preliminary tests and are satisfied with the performance and functionality of the mirrormaker. It should be considered proof-of-concept code to demonstrate the use-case.

If you have any questions, comments, or suggestions, let us know.