### PR TITLE
Reduce the amount of log messages during task retries

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -247,13 +247,15 @@ func (f *consumerFetcherRoutine) start() {
 						})
 
 						if err != nil {
-							if f.manager.client.IsOffsetOutOfRange(err) {
-								Warnf(f, "Current offset %d for topic %s and partition %s is out of range.", offset, nextTopicPartition.Topic, nextTopicPartition.Partition)
-								f.handleOffsetOutOfRange(&nextTopicPartition)
-							} else {
-								Warnf(f, "Got a fetch error: %s", err)
-								//TODO new backoff type?
-								time.Sleep(1 * time.Second)
+							if offset > -1 { // Negative offsets are obviously out of range but don't spam the logs...
+								if f.manager.client.IsOffsetOutOfRange(err) {
+									Warnf(f, "Current offset %d for topic %s and partition %s is out of range.", offset, nextTopicPartition.Topic, nextTopicPartition.Partition)
+									f.handleOffsetOutOfRange(&nextTopicPartition)
+								} else {
+									Warnf(f, "Got a fetch error: %s", err)
+									//TODO new backoff type?
+									time.Sleep(1 * time.Second)
+								}
 							}
 						}
 

--- a/workers.go
+++ b/workers.go
@@ -232,7 +232,7 @@ func (wm *WorkerManager) processBatch() {
 						task.Callee.OutputChannel = make(chan WorkerResult)
 					}
 
-					Warnf(wm, "Worker task %s has failed", result.Id())
+					Debugf(wm, "Worker task %s has failed", result.Id())
 					task.Retries++
 					if task.Retries > wm.config.MaxWorkerRetries {
 						Errorf(wm, "Worker task %s has failed after %d retries", result.Id(), wm.config.MaxWorkerRetries)
@@ -264,7 +264,7 @@ func (wm *WorkerManager) processBatch() {
 							}
 						}
 					} else {
-						Warnf(wm, "Retrying worker task %s %dth time", result.Id(), task.Retries)
+						Debugf(wm, "Retrying worker task %s %dth time", result.Id(), task.Retries)
 						time.Sleep(wm.config.WorkerBackoff)
 						go task.Callee.Start(task, wm.config.Strategy)
 					}


### PR DESCRIPTION
I believe most people only care when a task fails after max retries.  So I changed the log level of each retry to be a debug message and left the level as error when it fails more than max retries.