### PR TITLE
Timeout channel cleanup

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -302,10 +302,12 @@ func (f *consumerFetcherRoutine) addPartitions(partitionTopicInfos map[TopicAndP
 		Debugf(f, "Sending ask next to %s for %s", f, topicAndPartition)
 	Loop:
 		for {
+			timeout := time.NewTimer(1 * time.Second)
 			select {
 			case askNext <- topicAndPartition:
+				timeout.Stop()
 				break Loop
-			case <-time.After(1 * time.Second):
+			case <-timeout.C:
 				{
 					if f.manager.shuttingDown {
 						return


### PR DESCRIPTION
This replaces all non-testing uses of `time.After` with `time.NewTimer` and `timeout.Stop()`. This allows the garbage collector to remove the unused timeout channels faster, greatly reducing the number of inuse objects. This in turn speeds up garbage collection.