### PR TITLE
Allocate a new taskBatch for each batch of tasks in the WorkerManager

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -147,6 +147,7 @@ func (wm *WorkerManager) Stop() chan bool {
 
 func (wm *WorkerManager) startBatch(batch []*Message) {
 	inLock(&wm.stopLock, func() {
+		wm.currentBatch = newTaskBatch()
 		wm.batchOrder = make([]TaskId, 0)
 		for _, message := range batch {
 			topicPartition := TopicAndPartition{message.Topic, message.Partition}


### PR DESCRIPTION
#131 never releases the memory it allocates for taskBatches. Memory grows without bound, so processes using go_kafka_client will quickly run out of memory and die on HEAD right now.

Previously, we got around this by shrinking `currentBatch` - it was a map and we deleted entries. To avoid contention, we don't deleteEntries anymore, but we need to free up memory by dereferencing the taskBatch and allocating a new one.