### PR TITLE
Added 'Accept' header to requests to schema-registry and fix for long responses from schema-registry

### DIFF
--- a/schema_registry.go
+++ b/schema_registry.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -250,16 +251,20 @@ func (this *CachedSchemaRegistryClient) isOK(response *http.Response) bool {
 }
 
 func (this *CachedSchemaRegistryClient) handleSuccess(response *http.Response, model interface{}) error {
-	responseBytes := make([]byte, response.ContentLength)
-	response.Body.Read(responseBytes)
+	responseBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
 	return json.Unmarshal(responseBytes, model)
 }
 
 func (this *CachedSchemaRegistryClient) handleError(response *http.Response) error {
 	registryError := &ErrorMessage{}
-	responseBytes := make([]byte, response.ContentLength)
-	response.Body.Read(responseBytes)
-	err := json.Unmarshal(responseBytes, registryError)
+	responseBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(responseBytes, registryError)
 	if err != nil {
 		return err
 	}

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -18,11 +18,12 @@ package go_kafka_client
 import (
 	"encoding/json"
 	"fmt"
-	avro "github.com/stealthly/go-avro"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+
+	avro "github.com/stealthly/go-avro"
 )
 
 const (
@@ -239,6 +240,7 @@ func (this *CachedSchemaRegistryClient) newDefaultRequest(method string, uri str
 	if err != nil {
 		return nil, err
 	}
+	request.Header.Set("Accept", SCHEMA_REGISTRY_V1_JSON)
 	request.Header.Set("Content-Type", SCHEMA_REGISTRY_V1_JSON)
 	return request, nil
 }


### PR DESCRIPTION
1) Without explicitly set ‘Accept’ header registration of new Schema with schema-registry slave instance fails, because master instance rejects forwarded request with 500 Bad request status
2) response.Body.Read reads only first chunk of response and so breaks on longer schemas. As well as on longer debug error messages from schema-registry