### PR TITLE
Allow consumer configs to set the numWorkers and use full set of byte slices to check the partition number (for fixedpartiioner)

### DIFF
--- a/mirror_maker.go
+++ b/mirror_maker.go
@@ -157,7 +157,8 @@ func (this *MirrorMaker) startConsumers() {
 		if err != nil {
 			panic(err)
 		}
-		config.NumWorkers = 1
+		//Let the NumWorkers be set via consumer configs
+		//config.NumWorkers = 1
 		config.AutoOffsetReset = SmallestOffset
 		config.Coordinator = NewZookeeperCoordinator(zkConfig)
 		config.WorkerFailureCallback = func(_ *WorkerManager) FailedDecision {

--- a/producer.go
+++ b/producer.go
@@ -176,9 +176,12 @@ func (this *FixedPartitioner) Partition(key []byte, numPartitions int32) (int32,
 	if key == nil {
 		panic("FixedPartitioner does not work without keys.")
 	}
-	partition, err := binary.ReadUvarint(bytes.NewBuffer(key))
-	if err != nil {
-		return -1, err
+
+	var partition int32
+	buf := bytes.NewBuffer(key)
+	binary.Read(buf, binary.LittleEndian, &partition)
+	if (partition < 0) {
+		return -1, errors.New("Partition turned to be -1 (too big to be int32 little endian?)")
 	}
 
 	return int32(partition) % numPartitions, nil


### PR DESCRIPTION
First off, thanks a lot for this project. We started playing with mirroring of kafka and found the official mirrormaker lacking some features and all of them were covered with this project.

Now, we found two issues.

One is that some of our topics have a lot of partitions, we found that letting the consumer set the number of workers would speed up the mirroring of them so a part of this PR is to comment the "forced" numWorkers to 1. It would be nice to get this added but if not I'm *OK* in nuking this from the PR.

The second is something that I think needs to be fixed. One of our topics has about 300 partitions and we found that only partitions 0 to 127 would get mirrored (we preserve the partitions). After reading the code and also the sarama we came to the conclusion that sarama ByteEncoder (and this is documented on sarama) uses byte slices. Problem is not with byte slices, problem comes when producer.config tries to read the key (the partition #) _BUT_ it only reads the first slice...

So for example, if your partition # is 293, the representation would be:


 INPUT MESSAGE KEY (PARTITION) 293
 INPUT ENCODED) [37 1 0 0]
 OUTPUT ENCODED [37 1 0 0]
 OUTPUT ENCODED TYPE sarama.ByteEncoder
 OUTPUT FINAL PARTITION) 37

So the message would be producer to partition 37... when it should be 293. This is because:

partition, err := binary.ReadUvarint(bytes.NewBuffer(key))

ReadUvarint only reads slice by slice, so if you want to read the 4 slices you would need to call that 4 times, if you call it only one then you only get one slice (the first one). 

So rather than using ReadUvarint, just read the full []byte, convert it to buffer and then just convert it o a little endian 32bit integer.

$ go run example.go 
Sliced Bytes %v [37 1 0 0]
Int32 representation %v 293
Int32 (Bug) representation %v 37
Int32 (Bug) representation ERR %v <nil>

$ cat example.go
```
package main
import "fmt"
import "bytes"
import "encoding/binary"

func main() {
	// This is a 293 in sliced bytes
	b := make([]byte, 4)
	b[0] = 37
	b[1] = 1
	b[2] = 0
	b[3] = 0

	//21, 1
	var partitions int32
	buf := bytes.NewBuffer(b)
	binary.Read(buf, binary.LittleEndian, &partitions)

        buggyPartition, err := binary.ReadUvarint(bytes.NewBuffer(b))


	fmt.Println("Sliced Bytes %v", b)
	fmt.Println("Int32 representation %v", partitions)
	fmt.Println("Int32 (Bug) representation %v", buggyPartition)
	fmt.Println("Int32 (Bug) representation ERR %v", err)
}
```
